### PR TITLE
build: pin @types/node to the Node floor; hold toolchain majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,15 @@ updates:
       groups:
           dev-dependencies:
               dependency-type: development
+      ignore:
+          # TypeScript majors need the toolchain (openapi-typescript, api-extractor,
+          # typescript-eslint) to support them first; adopt deliberately, not via bot.
+          - dependency-name: 'typescript'
+            update-types: ['version-update:semver-major']
+          # Track @types/node to the minimum supported Node (engines >=20.3), not the
+          # latest, so APIs newer than the floor don't silently type-check.
+          - dependency-name: '@types/node'
+            update-types: ['version-update:semver-major']
     - package-ecosystem: github-actions
       directory: '/'
       schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "scoresaber.js",
-    "version": "0.4.0",
+    "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "scoresaber.js",
-            "version": "0.4.0",
+            "version": "1.0.0",
             "license": "MIT",
             "devDependencies": {
                 "@changesets/cli": "^2.31.0",
                 "@eslint/js": "^10.0.1",
                 "@microsoft/api-extractor": "^7.58.7",
-                "@types/node": "^24.13.1",
+                "@types/node": "^20.19.42",
                 "ajv": "^8.20.0",
                 "c8": "^11.0.0",
                 "eslint": "^10.4.1",
@@ -27,7 +27,7 @@
                 "typescript-eslint": "^8.60.1"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=20.3.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -2064,13 +2064,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.13.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
-            "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+            "version": "20.19.42",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
+            "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.18.0"
+                "undici-types": "~6.21.0"
             }
         },
         "node_modules/@types/unist": {
@@ -5581,9 +5581,9 @@
             "license": "MIT"
         },
         "node_modules/undici-types": {
-            "version": "7.18.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -7015,12 +7015,12 @@
             "dev": true
         },
         "@types/node": {
-            "version": "24.13.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
-            "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+            "version": "20.19.42",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
+            "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
             "dev": true,
             "requires": {
-                "undici-types": "~7.18.0"
+                "undici-types": "~6.21.0"
             }
         },
         "@types/unist": {
@@ -9148,9 +9148,9 @@
             "dev": true
         },
         "undici-types": {
-            "version": "7.18.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
             "dev": true
         },
         "universalify": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "@changesets/cli": "^2.31.0",
         "@eslint/js": "^10.0.1",
         "@microsoft/api-extractor": "^7.58.7",
-        "@types/node": "^24.13.1",
+        "@types/node": "^20.19.42",
         "ajv": "^8.20.0",
         "c8": "^11.0.0",
         "eslint": "^10.4.1",


### PR DESCRIPTION
- Pin @types/node to ^20 (was ^24) to match `engines: >=20.3`, so APIs newer than the supported Node floor don't silently type-check.
- Tell Dependabot to ignore major bumps for `typescript` and `@types/node`: TypeScript majors need openapi-typescript / api-extractor / typescript-eslint to support them first (TS 6 currently ERESOLVE-conflicts with openapi-typescript's `typescript@^5` peer), and @types/node should track the floor rather than latest. Minor/patch dev-dep updates still flow.
