### PR TITLE
Wait out rate limits instead of throwing

### DIFF
--- a/.changeset/rate-limit-wait-not-throw.md
+++ b/.changeset/rate-limit-wait-not-throw.md
@@ -1,0 +1,5 @@
+---
+'scoresaber.js': minor
+---
+
+Rate limiting now waits out limits instead of throwing. With `waitForRateLimit: true` (the default), a server `429` is waited out — honouring `Retry-After`, else the tracked bucket reset, else backoff — and retried until it clears, rather than throwing `RateLimitedError` after `maxRetries`. Buckets are tracked as monotonic per-window usage, so concurrent callers sharing a client can no longer overshoot a window via an optimistic header snapshot. Each bucket now also exposes a read-only `limit` (and `used`) on `client.rateLimit`. `maxRetries` continues to govern 5xx/network retries only, and `waitForRateLimit: false` is unchanged (still throws).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Typed Node.js client for the [ScoreSaber v2 API](https://scoresaber.com/api/docs
 
 - Response types generated from the live OpenAPI spec — re-runnable via `npm run gen:types`
 - Best-effort tracking of the three tiered rate-limit buckets (`long`/`medium`/`short`) with auto-wait when exhausted (opt-out for fail-fast)
-- Resilient by default: per-request timeout, and retries on HTTP 429/5xx and transient network errors with backoff
+- Resilient by default: per-request timeout, waits out rate limits, and retries 5xx / transient network errors with backoff
 - Lazy pagination via `AsyncIterable` — consumers control how much to fetch
 - Ships ESM **and** CommonJS; native `fetch`, zero runtime dependencies
 - Typed error hierarchy under `ScoreSaberError` so consumers can catch broadly or by code
@@ -56,7 +56,7 @@ new ScoreSaberClient({
     realmId?: number,            // applied to every request; default = active realm
     waitForRateLimit?: boolean,  // default true; false = throw RateLimitedError
     timeoutMs?: number,          // default 30000; per network attempt (not rate-limit waits)
-    maxRetries?: number,         // default 2; retries 429/5xx/network errors
+    maxRetries?: number,         // default 2; retries 5xx/network errors (429s are waited out, see below)
     userAgent?: string,          // override the default User-Agent
     maxResponseBytes?: number,   // reject responses larger than this
     onRequest?: (ctx) => void,   // hook: before each request attempt
@@ -132,11 +132,11 @@ Boolean-style filter params (e.g. `verified`, `hideNA`, `includePlayerScore`) ar
 
 ## Rate limit handling
 
-The client reads `x-ratelimit-remaining-{long,medium,short}` and `x-ratelimit-reset-{long,medium,short}` from each response and tracks every bucket independently, reserving capacity before each request so concurrent calls can't oversubscribe a bucket. When `waitForRateLimit: true` (default), it sleeps until the most-constrained bucket resets, and retries (up to `maxRetries`) if the API still returns HTTP 429 — honouring `Retry-After`. Set `waitForRateLimit: false` to throw `RateLimitedError` instead.
+The client reads `x-ratelimit-remaining-{long,medium,short}` and `x-ratelimit-reset-{long,medium,short}` from each response and tracks every bucket as monotonic per-window usage, reserving capacity before each request so concurrent calls can't oversubscribe a bucket (a later response's rosier count can't erase an in-flight reservation). When `waitForRateLimit: true` (default), it sleeps until the most-constrained bucket resets; and if the API still returns HTTP 429 it keeps waiting it out — honouring `Retry-After`, else the tracked bucket reset — until it clears, **not** bounded by `maxRetries` (`maxRetries` governs only 5xx/network). Cancel a wait via the call's `signal`. Set `waitForRateLimit: false` to throw `RateLimitedError` instead.
 
-`RateLimitedError` is the single type for both cases: a proactive throw (a tracked bucket is exhausted; `bucket` is set) and a server 429 the client won't retry (`status` is `429` and `url` is set; `bucket` is `undefined`). Either way `resetAt` tells you when to try again (`0` if unknown).
+`RateLimitedError` is only thrown when `waitForRateLimit: false`, and covers both cases: a proactive throw (a tracked bucket is exhausted; `bucket` is set) and a server 429 (`status` is `429` and `url` is set; `bucket` is `undefined`). Either way `resetAt` tells you when to try again (`0` if unknown).
 
-> These rate-limit header names are not part of the published OpenAPI spec; the limiter treats them as best-effort. If a header is absent or unrecognised, the corresponding bucket stays unbounded (no gating) rather than guessing. The opt-in integration suite verifies the contract against the live API.
+> These rate-limit header names are not part of the published OpenAPI spec; the limiter treats them as best-effort. Until the first response is seen — and whenever a header is absent or unrecognised — the corresponding bucket keeps a conservative default ceiling (gating from the first request) rather than going unbounded; the authoritative `x-ratelimit-limit-*` value replaces it once seen. The opt-in integration suite verifies the contract against the live API.
 
 A rate-limit wait isn't bounded by `timeoutMs` (that's per network attempt) — it ends when the window resets or when you abort the call's `signal`, whichever comes first.
 

--- a/etc/scoresaber.js.api.md
+++ b/etc/scoresaber.js.api.md
@@ -14,8 +14,10 @@ export type BucketName = 'long' | 'medium' | 'short';
 
 // @public
 export interface BucketState {
+    limit: number;
     remaining: number;
     resetAt: number;
+    used: number;
 }
 
 // @public
@@ -2499,7 +2501,7 @@ export type ScoreStats = GetResponse<'/api/v2/scores/{id}/stats'>;
 
 // Warnings were encountered during analysis:
 //
-// build/index.d.ts:134:9 - (ae-forgotten-export) The symbol "operations" needs to be exported by the entry point index.d.ts
+// build/index.d.ts:162:9 - (ae-forgotten-export) The symbol "operations" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,7 +20,11 @@ export interface ScoreSaberClientOptions {
      * `client.realm(id)` — both keep the single shared rate-limit budget.
      */
     realmId?: number;
-    /** Block until the rate-limit window refreshes when a bucket is exhausted. Defaults to `true`. */
+    /**
+     * Block until the rate-limit window refreshes when a bucket is exhausted, and wait
+     * out a server `429` (until it clears) rather than throwing. Defaults to `true`.
+     * Set `false` to throw `RateLimitedError` instead of waiting.
+     */
     waitForRateLimit?: boolean;
     /** Inject a fetch implementation (testing, custom agents). Defaults to global `fetch`. */
     fetch?: FetchLike;
@@ -31,7 +35,10 @@ export interface ScoreSaberClientOptions {
      * backoff. To cancel a request that is waiting, pass a `signal`.
      */
     timeoutMs?: number;
-    /** Retries on HTTP 429/5xx and transient network errors. Defaults to `2`. */
+    /**
+     * Retries on 5xx and transient network errors. Defaults to `2`. A `429` under
+     * `waitForRateLimit` is waited out separately and is not bounded by this.
+     */
     maxRetries?: number;
     /** Override the default `User-Agent` header. */
     userAgent?: string;

--- a/src/http.ts
+++ b/src/http.ts
@@ -42,7 +42,7 @@ export interface HttpClientOpts {
     defaultQuery?: QueryRecord;
     /** Per-request timeout in milliseconds. */
     timeoutMs: number;
-    /** Retries on HTTP 429/5xx and transient network errors. */
+    /** Retries on 5xx and transient network errors (a `429` under `waitForRateLimit` is waited out separately). */
     maxRetries: number;
     /** Reject responses whose Content-Length exceeds this many bytes. */
     maxResponseBytes?: number;
@@ -55,6 +55,11 @@ const RETRY_CAP_MS = 10_000;
 // Upper bound for any server-suggested wait (Retry-After). Caps pathological /
 // hostile values so they can't overflow setTimeout's 32-bit range.
 const MAX_WAIT_MS = 24 * 60 * 60 * 1000;
+// Floor for a rate-limit wait. The 429 retry loop is unbounded under
+// `waitForRateLimit`; a server pinning `Retry-After: 0` (or a sub-ms bucket reset)
+// would otherwise make it hammer the API every macrotask. This keeps the worst case
+// to a sane rate while still effectively "retry promptly".
+const MIN_RATE_LIMIT_WAIT_MS = 50;
 
 /** Encodes a query record, dropping undefined / null / empty values. Arrays are comma-joined. */
 function buildQuery(params: QueryRecord): string {
@@ -136,6 +141,7 @@ export class HttpClient {
         // reuse the reservation rather than decrementing every bucket again.
         await this.opts.rateLimiter.checkin(req?.signal);
 
+        let transientRetries = 0; // governs 5xx / network retries — NOT rate-limit waits
         for (let attempt = 0; ; attempt++) {
             const timeoutSignal = AbortSignal.timeout(this.opts.timeoutMs);
             const signal = req?.signal ? AbortSignal.any([req.signal, timeoutSignal]) : timeoutSignal;
@@ -148,7 +154,8 @@ export class HttpClient {
             } catch (err) {
                 if (req?.signal?.aborted) throw req.signal.reason; // caller cancelled — don't mask it
                 if (timeoutSignal.aborted) throw new ScoreSaberTimeoutError(url, this.opts.timeoutMs, {cause: err});
-                if (attempt < this.opts.maxRetries) {
+                if (transientRetries < this.opts.maxRetries) {
+                    transientRetries++;
                     await sleep(jitteredBackoffMs(attempt), req?.signal);
                     if (req?.signal?.aborted) throw req.signal.reason ?? err;
                     continue;
@@ -169,23 +176,34 @@ export class HttpClient {
                 }
             }
 
-            const retryable = response.status === 429 || response.status >= 500;
-            if (retryable && attempt < this.opts.maxRetries && (response.status !== 429 || this.opts.rateLimiter.waitForRateLimit)) {
+            // A 429 under waitForRateLimit is waited out and retried without bound — the
+            // limit is transient and self-clearing, so it must not consume maxRetries.
+            // Wait the time the server (Retry-After) or the tracked buckets say is needed,
+            // falling back to backoff only when neither is known.
+            if (response.status === 429 && this.opts.rateLimiter.waitForRateLimit) {
                 await response.body?.cancel();
-                const waitMs =
-                    response.status === 429
-                        ? (parseRetryAfterMs(response.headers.get('retry-after')) ?? jitteredBackoffMs(attempt))
-                        : jitteredBackoffMs(attempt);
+                const suggested =
+                    parseRetryAfterMs(response.headers.get('retry-after')) ??
+                    (this.opts.rateLimiter.exhaustedWaitMs() || jitteredBackoffMs(attempt));
+                const waitMs = Math.max(MIN_RATE_LIMIT_WAIT_MS, suggested);
                 await sleep(waitMs, req?.signal);
                 if (req?.signal?.aborted) throw req.signal.reason;
                 continue;
             }
 
+            // Transient 5xx: bounded by maxRetries.
+            if (response.status >= 500 && transientRetries < this.opts.maxRetries) {
+                transientRetries++;
+                await response.body?.cancel();
+                await sleep(jitteredBackoffMs(attempt), req?.signal);
+                if (req?.signal?.aborted) throw req.signal.reason;
+                continue;
+            }
+
             if (!response.ok) {
-                // A 429 we're not going to retry (retries exhausted, or
-                // waitForRateLimit disabled) surfaces as RateLimitedError so
-                // callers have a single rate-limit type to catch, matching the
-                // proactive path in RateLimiter.checkin.
+                // A 429 reaching here means waitForRateLimit is off: surface it as
+                // RateLimitedError so callers have a single rate-limit type to catch,
+                // matching the proactive path in RateLimiter.checkin.
                 if (response.status === 429) {
                     const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'));
                     await response.body?.cancel();

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -4,10 +4,14 @@ export type BucketName = 'long' | 'medium' | 'short';
 
 /** Snapshot of one rate-limit bucket. */
 export interface BucketState {
-    /** Requests remaining in the current window. */
+    /** Requests remaining in the current window: `max(0, limit - used)`. */
     remaining: number;
-    /** Unix milliseconds when the window resets. `0` until first response. */
+    /** Unix milliseconds when the window resets. `0` until first learned. */
     resetAt: number;
+    /** Window ceiling: a conservative default until the server reports it. */
+    limit: number;
+    /** Requests counted against the current window. */
+    used: number;
 }
 
 /** Read-only view of the limiter's tracked state — what `client.rateLimit` exposes. */
@@ -25,6 +29,25 @@ const BUCKETS: BucketName[] = ['long', 'medium', 'short'];
 // `x-ratelimit-reset-*` values so a huge number can't overflow setTimeout's
 // 32-bit range and busy-spin the wait loop. Real windows are seconds–minutes.
 const MAX_RESET_MS = 24 * 60 * 60 * 1000;
+
+// When a bucket is exhausted but we don't yet know its reset time (cold start,
+// before any response has populated `resetAt`), re-check after this interval — by
+// when an in-flight request's response should have set the real reset.
+const COLD_RECHECK_MS = 500;
+
+// Conservative ceilings used only until the server reports its real limits, so a
+// cold-start burst is throttled from the very first request rather than flooding
+// before we learn the limit. These mirror the observed ScoreSaber tiers and are
+// overwritten by the authoritative `x-ratelimit-limit-*` header on the first
+// response; a different deployment self-corrects the same way.
+const DEFAULT_LIMITS: Readonly<Record<BucketName, number>> = {long: 400, medium: 100, short: 25};
+
+/** Mutable per-bucket state. `used` is monotonic within a window; rollover zeroes it. */
+interface Bucket {
+    limit: number;
+    used: number;
+    resetAt: number;
+}
 
 /** Resolve when `p` settles or `signal` aborts, whichever first. Never rejects; the caller re-checks the signal. */
 function abortable(p: Promise<void>, signal?: AbortSignal): Promise<void> {
@@ -57,28 +80,69 @@ function waitFor(ms: number, signal?: AbortSignal): Promise<void> {
     });
 }
 
+function parseFinite(value: string | null): number | undefined {
+    if (value === null || value === '') return undefined;
+    const n = Number(value);
+    // `Number.isFinite` (not `!isNaN`) so an `Infinity` / absurd header can't push
+    // state out of setTimeout's range and busy-spin the wait loop.
+    return Number.isFinite(n) ? n : undefined;
+}
+
 /**
- * Tracks the three tiered ScoreSaber rate-limit buckets from response headers
- * and either waits for them to refresh or throws, depending on configuration.
+ * Tracks the three tiered ScoreSaber rate-limit buckets from response headers and
+ * either waits for them to refresh or throws, depending on configuration.
+ *
+ * Each bucket counts `used` requests monotonically within a window. The server's
+ * headers may only ever push `used` UP within a window (never down), so an
+ * in-flight burst's reservations can't be erased by a stale optimistic snapshot —
+ * which makes overshooting a window impossible by construction, even under
+ * concurrent callers sharing one client. A window rollover (its reset time having
+ * passed) zeroes `used` and the next response's refill is accepted.
  *
  * The exact header contract is not part of the published OpenAPI spec, so the
- * limiter is best-effort: absent or unrecognised headers leave the buckets
- * unbounded (no gating) rather than guessing.
+ * limiter is best-effort: until the first response is seen, each bucket uses a
+ * conservative default ceiling so a cold-start burst is still throttled.
  */
 export class RateLimiter implements RateLimitView {
-    public readonly long: BucketState = {remaining: Infinity, resetAt: 0};
-    public readonly medium: BucketState = {remaining: Infinity, resetAt: 0};
-    public readonly short: BucketState = {remaining: Infinity, resetAt: 0};
+    private readonly buckets: Record<BucketName, Bucket> = {
+        long: {limit: DEFAULT_LIMITS.long, used: 0, resetAt: 0},
+        medium: {limit: DEFAULT_LIMITS.medium, used: 0, resetAt: 0},
+        short: {limit: DEFAULT_LIMITS.short, used: 0, resetAt: 0},
+    };
 
     private gate: Promise<void> = Promise.resolve();
 
     constructor(public readonly waitForRateLimit: boolean) {}
 
+    public get long(): Readonly<BucketState> {
+        return this.view('long');
+    }
+    public get medium(): Readonly<BucketState> {
+        return this.view('medium');
+    }
+    public get short(): Readonly<BucketState> {
+        return this.view('short');
+    }
+
+    private view(name: BucketName): Readonly<BucketState> {
+        const b = this.buckets[name];
+        return {remaining: Math.max(0, b.limit - b.used), resetAt: b.resetAt, limit: b.limit, used: b.used};
+    }
+
+    /** A window whose reset time has passed is empty again. */
+    private rollover(b: Bucket, now: number): void {
+        if (b.resetAt > 0 && now >= b.resetAt) {
+            b.used = 0;
+            b.resetAt = 0;
+        }
+    }
+
     /**
-     * Reserve one request before sending. Concurrent callers are serialised
-     * through `gate` so they can't all pass a bucket that has a single request
-     * left; each caller decrements every bucket as it passes. Header updates
-     * later overwrite these estimates with the server's authoritative counts.
+     * Reserve one request before sending. Concurrent callers are serialised through
+     * `gate` so they can't all pass a bucket that has a single request left; each
+     * caller increments every bucket's `used` as it passes. Header updates later
+     * raise these estimates toward the server's authoritative counts but never lower
+     * them within a window.
      *
      * A caller `signal` cancels the wait promptly (throwing its reason), so an
      * aborted request doesn't block until the window resets.
@@ -95,18 +159,25 @@ export class RateLimiter implements RateLimitView {
                 let waitMs = 0;
                 let exhausted: BucketName | undefined;
                 for (const name of BUCKETS) {
-                    const b = this[name];
-                    if (b.remaining <= 0 && b.resetAt > now && b.resetAt - now > waitMs) {
-                        waitMs = b.resetAt - now;
-                        exhausted = name;
+                    const b = this.buckets[name];
+                    this.rollover(b, now);
+                    if (b.used >= b.limit) {
+                        // Known reset → wait exactly that long; unknown (cold start,
+                        // resetAt 0) → a short re-check, by when an in-flight response
+                        // should have populated the real reset.
+                        const wait = b.resetAt > now ? b.resetAt - now : COLD_RECHECK_MS;
+                        if (wait > waitMs) {
+                            waitMs = wait;
+                            exhausted = name;
+                        }
                     }
                 }
                 if (exhausted === undefined) {
-                    for (const name of BUCKETS) this[name].remaining -= 1;
+                    for (const name of BUCKETS) this.buckets[name].used += 1;
                     return;
                 }
                 if (!this.waitForRateLimit) {
-                    throw new RateLimitedError({bucket: exhausted, resetAt: this[exhausted].resetAt});
+                    throw new RateLimitedError({bucket: exhausted, resetAt: this.buckets[exhausted].resetAt});
                 }
                 await waitFor(waitMs + 100, signal);
                 if (signal?.aborted) throw signal.reason;
@@ -116,29 +187,65 @@ export class RateLimiter implements RateLimitView {
         }
     }
 
-    /** Update buckets from response headers. */
+    /**
+     * Update buckets from response headers. Within a window the server may only push
+     * `used` UP (the max rule); on a rollover the server's fresh, lower count is
+     * adopted. `limit` is learned from `x-ratelimit-limit-*` when present.
+     */
     public update(headers: Headers): void {
         const now = Date.now();
         for (const name of BUCKETS) {
-            const remaining = headers.get(`x-ratelimit-remaining-${name}`);
-            const reset = headers.get(`x-ratelimit-reset-${name}`);
-            // `Number.isFinite` (not `!isNaN`) plus a max clamp so an `Infinity`
-            // or absurdly large header can't push `resetAt` past setTimeout's range
-            // and busy-spin the wait loop. Real windows are seconds–minutes.
-            if (remaining !== null && remaining !== '' && Number.isFinite(Number(remaining))) {
-                this[name].remaining = Number(remaining);
+            const b = this.buckets[name];
+
+            const limit = parseFinite(headers.get(`x-ratelimit-limit-${name}`));
+            if (limit !== undefined) b.limit = limit;
+
+            // A window we were tracking whose reset has passed (or one never seen) is fresh:
+            // accept the server's lower count rather than holding a stale higher `used`.
+            const rolledOver = b.resetAt === 0 || now >= b.resetAt;
+
+            const remaining = parseFinite(headers.get(`x-ratelimit-remaining-${name}`));
+            if (remaining !== undefined) {
+                const serverUsed = Math.max(0, b.limit - remaining);
+                b.used = rolledOver ? serverUsed : Math.max(b.used, serverUsed);
             }
-            if (reset !== null && reset !== '' && Number.isFinite(Number(reset))) {
-                this[name].resetAt = now + Math.min(Math.max(0, Number(reset) * 1000), MAX_RESET_MS);
+
+            const reset = parseFinite(headers.get(`x-ratelimit-reset-${name}`));
+            if (reset !== undefined) {
+                const serverResetAt = now + Math.min(Math.max(0, reset * 1000), MAX_RESET_MS);
+                // Within a window we keep the later reset. This assumes the header counts
+                // DOWN toward the window end (ScoreSaber sends seconds-remaining), so
+                // successive `serverResetAt` values land at roughly the same instant and
+                // `now >= resetAt` eventually fires. A fixed-TTL header (constant value
+                // every response) would instead keep pushing `resetAt` forward and stall
+                // the rollover — not the observed contract, but the assumption is here.
+                b.resetAt = rolledOver ? serverResetAt : Math.max(b.resetAt, serverResetAt);
             }
         }
     }
 
     /**
-     * Reserve a slot in the serialised checkin chain. `wait` resolves when it is
-     * this caller's turn; `release` frees the slot for the next caller and MUST
-     * always be called (even if this caller aborts before its turn), or the chain
-     * stalls.
+     * Longest wait (ms) among buckets that are exhausted with a known future reset, or
+     * `0` if none. Used by the HTTP layer to wait out a server 429 for the time the
+     * buckets say is needed.
+     *
+     * Not a pure getter: it applies lazy rollover (zeroing buckets whose window has
+     * passed), like `checkin`, so the figure reflects current state.
+     */
+    public exhaustedWaitMs(now = Date.now()): number {
+        let waitMs = 0;
+        for (const name of BUCKETS) {
+            const b = this.buckets[name];
+            this.rollover(b, now);
+            if (b.used >= b.limit && b.resetAt > now) waitMs = Math.max(waitMs, b.resetAt - now);
+        }
+        return waitMs;
+    }
+
+    /**
+     * Reserve a slot in the serialised checkin chain. `wait` resolves when it is this
+     * caller's turn; `release` frees the slot for the next caller and MUST always be
+     * called (even if this caller aborts before its turn), or the chain stalls.
      */
     private acquire(): {wait: Promise<void>; release: () => void} {
         let release!: () => void;

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -124,26 +124,67 @@ describe('HTTP layer', () => {
         assert.equal(p.id, '1');
     });
 
-    test('stops retrying 429 once maxRetries is exhausted and throws RateLimitedError', async () => {
+    test('waitForRateLimit retries a 429 past maxRetries until it clears', async () => {
         let calls = 0;
-        const {client} = mockedClient(
-            () => {
-                calls += 1;
-                return jsonResponse({code: 'TOO_MANY_REQUESTS', message: 'slow down'}, {status: 429, headers: {'retry-after': '0'}});
-            },
-            {maxRetries: 1},
+        const {client} = mockedClient(() => {
+            calls += 1;
+            if (calls <= 3) {
+                // 429 with a ~10ms bucket reset and no Retry-After: it waits out the
+                // tracked reset (exhaustedWaitMs) and retries — fast, but a real wait.
+                return jsonResponse(
+                    {code: 'TOO_MANY_REQUESTS'},
+                    {status: 429, headers: {'x-ratelimit-remaining-short': '0', 'x-ratelimit-reset-short': '0.01'}},
+                );
+            }
+            return jsonResponse({id: '1', name: 'x'});
+        }); // default maxRetries = 2
+        const p = await client.players.getBasic('1');
+        assert.equal(p.id, '1');
+        assert.equal(calls, 4); // 3 x 429 then success — more than maxRetries, and it never threw
+    });
+
+    test('a 429 wait is cancellable via the caller signal', async () => {
+        const controller = new AbortController();
+        const {client} = mockedClient(() =>
+            // 429 with a 10s reset and no Retry-After: without abort this would block ~10s.
+            jsonResponse(
+                {code: 'TOO_MANY_REQUESTS'},
+                {status: 429, headers: {'x-ratelimit-remaining-short': '0', 'x-ratelimit-reset-short': '10'}},
+            ),
         );
+        const reason = new Error('cancelled');
+        setTimeout(() => controller.abort(reason), 20);
         await assert.rejects(
-            () => client.players.getBasic('1'),
-            (err: unknown) => {
-                assert.ok(err instanceof RateLimitedError);
-                assert.equal(err.status, 429);
-                assert.equal(err.bucket, undefined); // server 429 doesn't name a bucket
-                assert.match(err.url ?? '', /\/players\/1\/basic$/);
-                return true;
-            },
+            () => client.players.getBasic('1', {signal: controller.signal}),
+            (e: unknown) => e === reason,
         );
-        assert.equal(calls, 2); // initial + 1 retry
+    });
+
+    test('a 429 with Retry-After: 0 still waits a small floor between retries (no hot loop)', async () => {
+        let calls = 0;
+        const {client} = mockedClient(() => {
+            calls += 1;
+            if (calls <= 2) return jsonResponse({code: 'TOO_MANY_REQUESTS'}, {status: 429, headers: {'retry-after': '0'}});
+            return jsonResponse({id: '1', name: 'x'});
+        });
+        const before = Date.now();
+        const p = await client.players.getBasic('1');
+        const elapsed = Date.now() - before;
+        assert.equal(p.id, '1');
+        assert.equal(calls, 3);
+        assert.ok(elapsed >= 80, `expected a wait floor between retries (~2x50ms), only ${elapsed}ms`);
+    });
+
+    test('a bare 429 (no rate-limit headers) is waited out via backoff, not hung or thrown', async () => {
+        let calls = 0;
+        const {client} = mockedClient(() => {
+            calls += 1;
+            if (calls <= 2) return jsonResponse({code: 'TOO_MANY_REQUESTS'}, {status: 429}); // no retry-after, no bucket headers
+            return jsonResponse({id: '1', name: 'x'});
+        });
+        const p = await client.players.getBasic('1');
+        assert.equal(p.id, '1');
+        assert.equal(calls, 3); // fell back to jittered backoff and retried until success
     });
 
     test('a 429 surfaces as RateLimitedError (not ScoreSaberAPIError) when waitForRateLimit is off', async () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -44,14 +44,15 @@ describe('live API smoke', {skip: !ENABLED}, () => {
 
     test('rate-limit headers are surfaced on the client after a request', async () => {
         await client.players.getBasic(FIXTURE_PLAYER_ID);
-        // This is also a contract check: if the x-ratelimit-* header names or
-        // units ever drift from what rate-limit.ts assumes, the bucket stays at
-        // Infinity and these assertions fail loudly.
+        // Contract check: `resetAt` is only ever set by parsing `x-ratelimit-reset-*`,
+        // so if those header names or units drift from what rate-limit.ts assumes it
+        // stays 0 and this fails loudly. (`remaining` can't serve as the signal — a
+        // checkin's own reservation lowers it below the default ceiling even with no
+        // headers, so it no longer distinguishes "parsed" from "unparsed".)
         assert.ok(
-            client.rateLimit.long.remaining < 400,
-            `long bucket still unbounded — the x-ratelimit-* header contract may have changed (got ${client.rateLimit.long.remaining})`,
+            client.rateLimit.long.resetAt > Date.now(),
+            `long bucket reset not surfaced from headers — the x-ratelimit-* contract may have changed (resetAt=${client.rateLimit.long.resetAt})`,
         );
-        assert.ok(client.rateLimit.long.resetAt > Date.now());
     });
 
     test('server honours leaderboard filters (regression guard for dropped query params)', async () => {

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -10,8 +10,10 @@ function makeHeaders(values: Record<string, string>): Headers {
 }
 
 describe('RateLimiter', () => {
-    test('starts with infinite remaining so first request is not blocked', async () => {
+    test('starts with a default budget so the first request is not blocked', async () => {
         const rl = new RateLimiter(true);
+        assert.equal(rl.short.remaining, 25); // conservative default until the server reports its limit
+        assert.equal(rl.short.limit, 25);
         const before = Date.now();
         await rl.checkin();
         assert.ok(Date.now() - before < 50, 'first checkin should return immediately');
@@ -36,6 +38,41 @@ describe('RateLimiter', () => {
         const now = Date.now();
         assert.ok(Math.abs(rl.long.resetAt - (now + 60_000)) < 1000);
         assert.ok(Math.abs(rl.short.resetAt - (now + 1000)) < 1000);
+    });
+
+    test('exposes a per-bucket limit, learned from the header', () => {
+        const rl = new RateLimiter(true);
+        assert.equal(rl.short.limit, 25); // default before any response
+        rl.update(
+            makeHeaders({
+                'x-ratelimit-limit-short': '30',
+                'x-ratelimit-remaining-short': '29',
+                'x-ratelimit-reset-short': '1',
+            }),
+        );
+        assert.equal(rl.short.limit, 30);
+        assert.equal(rl.short.remaining, 29);
+    });
+
+    test('an optimistic server snapshot cannot lower used within a window (no overshoot)', () => {
+        const rl = new RateLimiter(true);
+        // Establish a window: used jumps to 20 of 25, resets in 60s.
+        rl.update(makeHeaders({'x-ratelimit-remaining-short': '5', 'x-ratelimit-reset-short': '60'}));
+        assert.equal(rl.short.used, 20);
+        // A later response in the SAME window reports a rosier remaining (server-used 8).
+        rl.update(makeHeaders({'x-ratelimit-remaining-short': '17', 'x-ratelimit-reset-short': '59'}));
+        assert.equal(rl.short.used, 20); // max rule: not lowered to 8
+        assert.equal(rl.short.remaining, 5);
+    });
+
+    test('a window rollover accepts the server refill', () => {
+        const rl = new RateLimiter(true);
+        // Exhausted, window already expired.
+        rl.update(makeHeaders({'x-ratelimit-remaining-short': '0', 'x-ratelimit-reset-short': '0'}));
+        // Next response is a fresh window with budget again.
+        rl.update(makeHeaders({'x-ratelimit-remaining-short': '24', 'x-ratelimit-reset-short': '1'}));
+        assert.equal(rl.short.used, 1);
+        assert.equal(rl.short.remaining, 24);
     });
 
     test('throws RateLimitedError when a bucket is exhausted and waitForRateLimit=false', async () => {
@@ -79,7 +116,8 @@ describe('RateLimiter', () => {
         const waited = Date.now() - before;
         // It must actually enter the wait loop (not return immediately) and then resolve.
         assert.ok(waited >= 250, `expected to block until the window reset, only waited ${waited}ms`);
-        assert.equal(rl.short.remaining, -1); // decremented once it finally passes
+        assert.equal(rl.short.used, 1); // window rolled over, then this request reserved one
+        assert.equal(rl.short.remaining, 24); // 25 default limit - 1 used
     });
 
     test('update ignores non-finite reset headers (no busy-spin from Infinity)', () => {
@@ -99,12 +137,21 @@ describe('RateLimiter', () => {
         assert.ok(rl.short.resetAt <= now + 24 * 60 * 60 * 1000 + 1000, `resetAt should be clamped, got ${rl.short.resetAt}`);
     });
 
-    test('update leaves buckets unbounded when their headers are absent', () => {
+    test('update keeps a bucket at its default ceiling when its headers are absent', () => {
         const rl = new RateLimiter(true);
         rl.update(makeHeaders({'x-ratelimit-remaining-long': '300', 'x-ratelimit-reset-long': '60'}));
         assert.equal(rl.long.remaining, 300);
-        assert.equal(rl.medium.remaining, Infinity);
-        assert.equal(rl.short.remaining, Infinity);
+        assert.equal(rl.medium.remaining, 100); // default ceiling, untouched
+        assert.equal(rl.short.remaining, 25); // default ceiling, untouched
+    });
+
+    test('cold start throttles a concurrent burst to the default ceiling', async () => {
+        const rl = new RateLimiter(false); // throw rather than wait, so we can count what passes
+        // No update() yet: limits are the conservative defaults. short = 25.
+        const attempts = Array.from({length: 27}, () => rl.checkin());
+        const results = await Promise.allSettled(attempts);
+        const passed = results.filter((r) => r.status === 'fulfilled').length;
+        assert.equal(passed, 25); // exactly the default short ceiling; the rest throw
     });
 
     test('reserves capacity so concurrent checkins cannot oversubscribe a bucket', async () => {


### PR DESCRIPTION
Under `waitForRateLimit: true` (the default), a server 429 is now waited out — honouring `Retry-After`, else the tracked bucket reset — and retried until it clears, instead of throwing `RateLimitedError` after `maxRetries`. `maxRetries` now governs only 5xx/network retries.

Buckets are tracked as monotonic per-window usage, so concurrent callers sharing a client can't overshoot a window via an optimistic header snapshot. Each bucket also exposes read-only `limit`/`used` on `client.rateLimit`. `waitForRateLimit: false` is unchanged (still throws). Changeset included (minor).
